### PR TITLE
Update the background color of uneditable parts

### DIFF
--- a/files/kusted_kontent_app_concise.css
+++ b/files/kusted_kontent_app_concise.css
@@ -1,6 +1,12 @@
 /* Make the uneditable parts of elements different from the editable parts */
 .content-item-element__wrapper {
-    background: rgba(255, 255, 255, 0.5);
+    background: repeating-linear-gradient(
+      45deg,
+      #e4e7eb,
+      #edf0f5 5px,
+      #e4e7eb 1px,
+      #edf0f5 10px
+    );
 }
 
 /* Make the editable parts of elements white again */


### PR DESCRIPTION
Make the background color of uneditable parts of elements in content items more distinct from the editable parts because previously, it was almost an invisible difference. Now the BG are diagonal stripes of light colors that are unobtrusive but distinctively different from the rest of the UI. Tested using the Stylish extension.